### PR TITLE
Add support for Mermaid configuration options, version and style

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,18 @@ exports.handlers = {
     if (htmls) {
       e.doclet.description = e.doclet.description || ''
       if (!isAddedMermaid[e.doclet.memberof]) {
-        e.doclet.description += '<script src="https://unpkg.com/mermaid@8.3.0/dist/mermaid.min.js"></script>'
+        e.doclet.description += '<script src="https://unpkg.com/mermaid@8.5.0/dist/mermaid.min.js"></script>\n' +
+          '<script>\n' +
+          'var config = {\n' +
+          '  startOnLoad:true,\n' +
+          '  flowchart:{\n' +
+          '    useMaxWidth:false,\n' +
+          '    htmlLabels:true\n' +
+          '  }\n' +
+          '};\n' +
+          'console.log("initializing mermaid...");\n' +
+          'mermaid.initialize(config);\n' +
+          '</script>'
         isAddedMermaid[e.doclet.memberof] = true
       }
       e.doclet.description += htmls.join('')

--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 const doctrine = require('doctrine')
 
+// get access to configuration options
+const env = require('jsdoc/env');
+const config = env.conf.mermaid || {};
+
 const escapeHtmlChar = {
   '&': '&amp;',
   '<': '&lt;',
@@ -22,18 +26,10 @@ exports.handlers = {
     if (htmls) {
       e.doclet.description = e.doclet.description || ''
       if (!isAddedMermaid[e.doclet.memberof]) {
-        e.doclet.description += '<script src="https://unpkg.com/mermaid@8.5.0/dist/mermaid.min.js"></script>\n' +
-          '<script>\n' +
-          'var config = {\n' +
-          '  startOnLoad:true,\n' +
-          '  flowchart:{\n' +
-          '    useMaxWidth:false,\n' +
-          '    htmlLabels:true\n' +
-          '  }\n' +
-          '};\n' +
-          'console.log("initializing mermaid...");\n' +
-          'mermaid.initialize(config);\n' +
-          '</script>'
+        var version = config.version ? '@' + config.version : ''
+        delete config.version
+        e.doclet.description += '<script src="https://unpkg.com/mermaid' + version + '/dist/mermaid.min.js"></script>\n' +
+          '<script>mermaid.initialize(' + JSON.stringify(config) + ');</script>\n'
         isAddedMermaid[e.doclet.memberof] = true
       }
       e.doclet.description += htmls.join('')

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ exports.handlers = {
       if (htmls) {
         e.doclet.description = e.doclet.description || ''
 
-        if (!isAddedMermaid[e.doclet.memberof]) {
+        if (!isAddedMermaid[e.doclet.memberof] && !MERMAID_CONFIG.disableScript) {
           let version = MERMAID_CONFIG.version ? '@' + MERMAID_CONFIG.version : ''
 
           // clone the Mermaid config so we can remove our unique options before rendering via JSON.stringify

--- a/index.js
+++ b/index.js
@@ -22,14 +22,14 @@ exports.handlers = {
   newDoclet: function (e) {
     if (!e.doclet.comment || !/@mermaid\b/.test(e.doclet.comment)) return
     let tags = doctrine.parse(e.doclet.comment, { unwrap: true, tags: ['mermaid'], recoverable: true }).tags
-    var style = config.style ? ' style="' + config.style + '"' : ''
+    let style = config.style ? ' style="' + config.style + '"' : ''
     let htmls = tags.map(tag => '<div class="mermaid"' + style + '>' + escapeHtml(tag.description) + '</div>')
 
     if (htmls) {
       e.doclet.description = e.doclet.description || ''
       if (!isAddedMermaid[e.doclet.memberof]) {
-        var version = config.version ? '@' + config.version : ''
-        var altConfig = {...config}
+        let version = config.version ? '@' + config.version : ''
+        let altConfig = {...config}
         delete altConfig.version
         delete altConfig.style
         e.doclet.description += 

--- a/index.js
+++ b/index.js
@@ -22,14 +22,19 @@ exports.handlers = {
   newDoclet: function (e) {
     if (!e.doclet.comment || !/@mermaid\b/.test(e.doclet.comment)) return
     let tags = doctrine.parse(e.doclet.comment, { unwrap: true, tags: ['mermaid'], recoverable: true }).tags
-    let htmls = tags.map(tag => '<div class="mermaid">' + escapeHtml(tag.description) + '</div>')
+    var style = config.style ? ' style="' + config.style + '"' : ''
+    let htmls = tags.map(tag => '<div class="mermaid"' + style + '>' + escapeHtml(tag.description) + '</div>')
+
     if (htmls) {
       e.doclet.description = e.doclet.description || ''
       if (!isAddedMermaid[e.doclet.memberof]) {
         var version = config.version ? '@' + config.version : ''
-        delete config.version
-        e.doclet.description += '<script src="https://unpkg.com/mermaid' + version + '/dist/mermaid.min.js"></script>\n' +
-          '<script>mermaid.initialize(' + JSON.stringify(config) + ');</script>\n'
+        var altConfig = {...config}
+        delete altConfig.version
+        delete altConfig.style
+        e.doclet.description += 
+          '<script src="https://unpkg.com/mermaid' + version + '/dist/mermaid.min.js"></script>\n' +
+          '<script>mermaid.initialize(' + JSON.stringify(altConfig) + ');</script>\n'
         isAddedMermaid[e.doclet.memberof] = true
       }
       e.doclet.description += htmls.join('')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsdoc-mermaid",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A tool to automagically create flowcharts and diagrams in your jsdocs.",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -4,19 +4,30 @@ A plugin that parses your JSDocs for [Mermaid](https://mermaidjs.github.io/) syn
 
 ## Custom changes on this branch
 
-This branch was forked from the original [Jellyvision](https://github.com/Jellyvision/jsdoc-mermaid) implementation to add the ability to pass options to Mermaid from the JSDoc configuration file (typically ```conf.json```).  This let's you add a ```mermaid``` section and provide any Mermaid options you want.  See [Mermaid API](https://mermaid-js.github.io/mermaid/#/mermaidAPI) and also the [code that implements the defaults](https://github.com/mermaid-js/mermaid/blob/master/src/mermaidAPI.js) (which helps to see all options as the documentation isn't fully up to date).
+This branch was forked from the original [Jellyvision](https://github.com/Jellyvision/jsdoc-mermaid) implementation to add the ability to pass options to Mermaid from the JSDoc configuration file (typically ```conf.json```).  This let's you add a ```mermaid``` section and provide any Mermaid options you want.  
 
-It also adds a new property ```version``` where you can specify the Mermaid version to use.  Otherwise it defaults to latest.
+## Documentation on Mermaid
+
+* [Mermaid API](https://mermaid-js.github.io/mermaid/#/mermaidAPI), however the properties are often incorrect
+* [Mermaid configuration defaults](https://mermaid-js.github.io/mermaid/#/mermaidAPI?id=mermaidapi-configuration-defaults) shows the defaults, and appears to be more accurate
+* [Source code for the API](https://github.com/mermaid-js/mermaid/blob/master/src/mermaidAPI.js) which is harder to parse but the most accurate
+
+This package also some new properties to the mermaid configuration:
+
+* ```version```: Let's you specify which Mermaid version to use.  If not provided, defaults to latest Mermaid.
+* ```style```: Let's you add optional CSS styles to the surrounding ```<div>``` tag (which also has class ```mermaid``` if you want to use a proper stylesheet).
 
 For example:
 
 ```json
 {
   "mermaid": {
-    "theme": "forest",
+    "theme": "nuetral",
+    "style": "display: flex",
     "version": "8.3.0",
     "flowchart": {
-      "curve": "cardinal"
+      "curve": "cardinal",
+      "htmlLabels": false
     }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,27 @@
 
 A plugin that parses your JSDocs for [Mermaid](https://mermaidjs.github.io/) syntax and renders the diagrams and flowcharts described.
 
+## Custom changes on this branch
+
+This branch was forked from the original [Jellyvision](https://github.com/Jellyvision/jsdoc-mermaid) implementation to add the ability to pass options to Mermaid from the JSDoc configuration file (typically ```conf.json```).  This let's you add a ```mermaid``` section and provide any Mermaid options you want.  See [Mermaid API](https://mermaid-js.github.io/mermaid/#/mermaidAPI) and also the [code that implements the defaults](https://github.com/mermaid-js/mermaid/blob/master/src/mermaidAPI.js) (which helps to see all options as the documentation isn't fully up to date).
+
+It also adds a new property ```version``` where you can specify the Mermaid version to use.  Otherwise it defaults to latest.
+
+For example:
+
+```json
+{
+  "mermaid": {
+    "theme": "forest",
+    "version": "8.3.0",
+    "flowchart": {
+      "curve": "cardinal"
+    }
+  }
+}
+```
+
+
 ## Getting Started
 
 ```bash
@@ -11,7 +32,7 @@ yarn add -D jsdoc-mermaid # OR npm install -D jsdoc-mermaid
 
 And then add `jsdoc-mermaid` to your jsdoc configuration file. That's it!
 
-```javascript
+```json
 {
     "plugins": ["jsdoc-mermaid"]
 }

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,7 @@ This package also supports some new properties to the mermaid configuration:
 
 * ```version```: Let's you specify which Mermaid version to use.  If not provided, defaults to latest Mermaid.
 * ```style```: Let's you add optional CSS styles to the surrounding ```<div>``` tag (which also has class ```mermaid``` if you want to use a proper stylesheet).
+* ```disableScript```: When true, disables the generation of the script for including Mermaid and initializing it.  This is sometimes needed when using a template that already has Mermaid scripting.  Continues to provide  ```<div class="mermaid">``` around the ```@mermaid``` sections.
 
 ```json
 {

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ You can optionally include a section in your JSDoc configuration file (such as `
 }
 ```
 
-This package also some new properties to the mermaid configuration:
+This package also supports some new properties to the mermaid configuration:
 
 * ```version```: Let's you specify which Mermaid version to use.  If not provided, defaults to latest Mermaid.
 * ```style```: Let's you add optional CSS styles to the surrounding ```<div>``` tag (which also has class ```mermaid``` if you want to use a proper stylesheet).

--- a/readme.md
+++ b/readme.md
@@ -2,38 +2,6 @@
 
 A plugin that parses your JSDocs for [Mermaid](https://mermaidjs.github.io/) syntax and renders the diagrams and flowcharts described.
 
-## Custom changes on this branch
-
-This branch was forked from the original [Jellyvision](https://github.com/Jellyvision/jsdoc-mermaid) implementation to add the ability to pass options to Mermaid from the JSDoc configuration file (typically ```conf.json```).  This let's you add a ```mermaid``` section and provide any Mermaid options you want.  
-
-## Documentation on Mermaid
-
-* [Mermaid API](https://mermaid-js.github.io/mermaid/#/mermaidAPI), however the properties are often incorrect
-* [Mermaid configuration defaults](https://mermaid-js.github.io/mermaid/#/mermaidAPI?id=mermaidapi-configuration-defaults) shows the defaults, and appears to be more accurate
-* [Source code for the API](https://github.com/mermaid-js/mermaid/blob/master/src/mermaidAPI.js) which is harder to parse but the most accurate
-
-This package also some new properties to the mermaid configuration:
-
-* ```version```: Let's you specify which Mermaid version to use.  If not provided, defaults to latest Mermaid.
-* ```style```: Let's you add optional CSS styles to the surrounding ```<div>``` tag (which also has class ```mermaid``` if you want to use a proper stylesheet).
-
-For example:
-
-```json
-{
-  "mermaid": {
-    "theme": "nuetral",
-    "style": "display: flex",
-    "version": "8.3.0",
-    "flowchart": {
-      "curve": "cardinal",
-      "htmlLabels": false
-    }
-  }
-}
-```
-
-
 ## Getting Started
 
 ```bash
@@ -80,6 +48,43 @@ jsdoc book.js -c conf.json
 When you open that page in JSDoc, you should have a shiny new graph!
 
 ![jsdoc-mermaid example](https://user-images.githubusercontent.com/2096353/31104126-b9159786-a7a0-11e7-95ed-689a7f158803.png)
+
+## Customizing Mermaid
+
+You can optionally include a section in your JSDoc configuration file (such as ```conf.json```) to define Mermaid custom configurations.  Simply add a section called ```"mermaid"```:
+
+```json
+{
+  "mermaid": {
+    "theme": "forest"
+  }
+}
+```
+
+This package also some new properties to the mermaid configuration:
+
+* ```version```: Let's you specify which Mermaid version to use.  If not provided, defaults to latest Mermaid.
+* ```style```: Let's you add optional CSS styles to the surrounding ```<div>``` tag (which also has class ```mermaid``` if you want to use a proper stylesheet).
+
+```json
+{
+  "mermaid": {
+    "theme": "nuetral",
+    "style": "display: flex",
+    "version": "8.3.0",
+    "flowchart": {
+      "curve": "cardinal",
+      "htmlLabels": false
+    }
+  }
+}
+```
+
+### Mermaid configuration documentation
+
+* [Mermaid API](https://mermaid-js.github.io/mermaid/#/mermaidAPI), however the properties are often incorrect
+* [Mermaid configuration defaults](https://mermaid-js.github.io/mermaid/#/mermaidAPI?id=mermaidapi-configuration-defaults) shows the defaults, and appears to be more accurate
+* [Source code for the API](https://github.com/mermaid-js/mermaid/blob/master/src/mermaidAPI.js) which is harder to parse but the most accurate
 
 
 ## Built With


### PR DESCRIPTION
This pull has the following features:
* Added a new ```mermaid``` section to ```conf.json``` to allow all Mermaid configuration options to be used
* Added new ```version``` option to specify the Mermaid version to use, defaulting to latest Mermaid when not specified
* Added new ```style``` option to set CSS style options on the surrounding ```<div>```
* Updated README to document the above and include some helpful links to Mermaid documentation

As an aside, the prior Mermaid version used had a sizing problem with classDiagram (massive rendering), but the latest (8.5.0) messes up graph (very tall boxes around boxes).  If you set the flowchart option ```"htmlLabels": false``` this problem goes away.  This is shown in the example configuration in the README, but hopefully this problem will be fixed in a future Mermaid release.